### PR TITLE
chore: remove prepare script on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "digital-credentials",
   "description": "Digital Credentials API and Passkey in typescript",
   "scripts": {
-    "prepare": "pnpm run build",
     "build": "lerna run build --stream",
     "lint": "biome lint ./packages",
     "format": "biome format . --write",


### PR DESCRIPTION
The prepare script has been removed since the project now automatically builds whenever we add a new package.