### PR TITLE
feat: change grant empty when contents are not exist

### DIFF
--- a/packages/oid4vci-nestjs/src/oid4vci.service.ts
+++ b/packages/oid4vci-nestjs/src/oid4vci.service.ts
@@ -146,15 +146,15 @@ export class Oid4VciService {
           credential_configuration_ids = [],
         } = options;
 
+        const grants =
+          issuer_state || authorization_server
+            ? { authorization_code: { issuer_state, authorization_server } }
+            : undefined;
+
         const rawCredentialOffer = {
           credential_issuer: this.options.meta.credential_issuer,
           credential_configuration_ids,
-          grants: {
-            authorization_code: {
-              issuer_state,
-              authorization_server,
-            },
-          },
+          grants,
         };
         const credentialOffer =
           this.credentialOfferUri.byValue(rawCredentialOffer);

--- a/packages/oid4vci-nestjs/src/types/credential_offer.ts
+++ b/packages/oid4vci-nestjs/src/types/credential_offer.ts
@@ -62,7 +62,7 @@ export type Grant = AuthorizationCodeGrant | PreAuthorizedCodeGrant;
 export type CredentialOffer = {
   credential_issuer: string;
   credential_configuration_ids: string[];
-  grants: Grant;
+  grants?: Grant;
 };
 
 /**


### PR DESCRIPTION
`grants` in credential offer is optional. So make it undefined when contents are empty