### PR TITLE
feat: Implement oid4vci-client package

### DIFF
--- a/examples/oid4vci-client/package.json
+++ b/examples/oid4vci-client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "oid4vci-client",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "rm -rf **/dist && tsup",
+    "start": "npm run build && node dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "tsup": {
+    "entry": [
+      "./src/index.ts"
+    ],
+    "sourceMap": true,
+    "splitting": false,
+    "clean": true,
+    "dts": true,
+    "format": [
+      "cjs",
+      "esm"
+    ]
+  },
+  "dependencies": {
+    "@vdcs/oid4vci-client": "workspace:*",
+    "@vdcs/oid4vci": "workspace:*"
+  },
+  "keywords": []
+}

--- a/examples/oid4vci-client/src/index.ts
+++ b/examples/oid4vci-client/src/index.ts
@@ -1,0 +1,51 @@
+import { Oid4VciClient } from '@vdcs/oid4vci-client';
+import {
+  CredentialOffer,
+  PreAuthorizedCodeGrant,
+  isPreAuthorizedCodeGrant,
+} from '@vdcs/oid4vci';
+
+async function run() {
+  const issuerUrl = 'https://issuer.dev.hopae.com';
+  const txCode = '1111';
+  const credentialType = 'UniversityDegreeCredential';
+
+  const client = new Oid4VciClient(issuerUrl);
+
+  const credentialOffer = await client.fetchCredentialOffer();
+  console.log('Credential Offer:', credentialOffer);
+
+  const credentialIsserMetadata = await client.fetchCredentialIssuerMetadata();
+  console.log('Credential Issuer Metadata:', credentialIsserMetadata);
+
+  const authorizationServerMetadata =
+    await client.fetchAuthorizationServerMetadata();
+  console.log('Authorization Server Metadata:', authorizationServerMetadata);
+
+  if (isPreAuthorizedCodeGrant(credentialOffer)) {
+    const preAuthorizedGrant =
+      credentialOffer.grants[
+        'urn:ietf:params:oauth:grant-type:pre-authorized_code'
+      ];
+
+    // @Todo: fix type after server url replaced ("pre-authorized_code" is used in "example-issuer-server")
+    const preAuthorizedCode = (preAuthorizedGrant as any)[
+      'pre-authorized_code'
+    ];
+
+    console.log('Pre-authorized code:', preAuthorizedCode, preAuthorizedGrant);
+
+    const accessToken = await client.getAccessToken(preAuthorizedCode, txCode);
+    console.log('Access Token:', accessToken);
+
+    const credential = await client.requestCredential(
+      accessToken,
+      credentialType,
+    );
+    console.log('Credential:', credential);
+  } else {
+    // @Todo: handle authorization flow
+  }
+}
+
+run().catch(console.error);

--- a/examples/oid4vci-client/tsconfig.json
+++ b/examples/oid4vci-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/oid4vci-client/package.json
+++ b/packages/oid4vci-client/package.json
@@ -55,5 +55,9 @@
       "cjs",
       "esm"
     ]
+  },
+  "dependencies": {
+    "axios": "^1.8.2",
+    "@vdcs/oid4vci": "workspace:*"
   }
 }

--- a/packages/oid4vci-client/src/client.ts
+++ b/packages/oid4vci-client/src/client.ts
@@ -1,0 +1,86 @@
+import axios, { AxiosInstance } from 'axios';
+import {
+  CredentialOffer,
+  CredentialResponse,
+  CredentialIssuerMetadata,
+  AuthorizationServerMetadata,
+} from '@vdcs/oid4vci';
+
+export class Oid4VciClient {
+  private axios: AxiosInstance;
+  private currentOffer: CredentialOffer | null = null;
+  private credentialIssuerMetadata: CredentialIssuerMetadata | null = null;
+  private authorizationServerMetadata: AuthorizationServerMetadata | null =
+    null;
+
+  constructor(private issuerUrl: string) {
+    this.axios = axios.create();
+  }
+  async fetchCredentialOffer(): Promise<CredentialOffer> {
+    const url = `${this.issuerUrl}/credential-offer`;
+    const response = await this.axios.get<CredentialOffer>(url);
+    this.currentOffer = response.data;
+
+    return this.currentOffer;
+  }
+
+  async fetchCredentialIssuerMetadata(): Promise<CredentialIssuerMetadata> {
+    const url = `${this.issuerUrl}/.well-known/openid-credential-issuer`;
+    const response = await this.axios.get<CredentialIssuerMetadata>(url);
+    this.credentialIssuerMetadata = response.data;
+    return response.data;
+  }
+
+  async fetchAuthorizationServerMetadata(): Promise<AuthorizationServerMetadata> {
+    const url = `${this.issuerUrl}/.well-known/oauth-authorization-server`;
+    const response = await this.axios.get<AuthorizationServerMetadata>(url);
+    this.authorizationServerMetadata = response.data;
+    return response.data;
+  }
+
+  async getAccessToken(
+    preAuthorizedCode: string,
+    txCode: string,
+  ): Promise<string> {
+    if (!this.authorizationServerMetadata) {
+      throw new Error(
+        'Metadata not loaded. Call fetchAuthorizationServerMetadata() first.',
+      );
+    }
+
+    const response = await this.axios.post(
+      this.authorizationServerMetadata.token_endpoint,
+      {
+        grant_type: 'urn:ietf:params:oauth:grant-type:pre-authorized_code',
+        pre_authorized_code: preAuthorizedCode,
+        tx_code: txCode,
+      },
+    );
+
+    return response.data.access_token;
+  }
+
+  async requestCredential(
+    accessToken: string,
+    credentialType: string,
+  ): Promise<CredentialResponse> {
+    if (!this.credentialIssuerMetadata) {
+      throw new Error('Metadata not loaded. Call fetchMetadata() first.');
+    }
+
+    const response = await this.axios.post(
+      this.credentialIssuerMetadata.credential_endpoint,
+      {
+        credential_identifier: credentialType,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return response.data;
+  }
+}

--- a/packages/oid4vci-client/src/index.ts
+++ b/packages/oid4vci-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from './client';

--- a/packages/oid4vci/src/index.ts
+++ b/packages/oid4vci/src/index.ts
@@ -1,3 +1,5 @@
 export * from './types/credential';
 export * from './types/credential_offer';
 export * from './types/metadata';
+
+export * from './utils';

--- a/packages/oid4vci/src/utils/index.ts
+++ b/packages/oid4vci/src/utils/index.ts
@@ -1,0 +1,13 @@
+import {
+  PreAuthorizedCodeGrant,
+  CredentialOffer,
+} from '../types/credential_offer';
+
+export function isPreAuthorizedCodeGrant(
+  offer: CredentialOffer,
+): offer is CredentialOffer & { grants: PreAuthorizedCodeGrant } {
+  return (
+    !!offer.grants &&
+    'urn:ietf:params:oauth:grant-type:pre-authorized_code' in offer.grants
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,15 @@ importers:
         specifier: ^5.3.3
         version: 5.7.3
 
+  examples/oid4vci-client:
+    dependencies:
+      '@vdcs/oid4vci':
+        specifier: workspace:*
+        version: link:../../packages/oid4vci
+      '@vdcs/oid4vci-client':
+        specifier: workspace:*
+        version: link:../../packages/oid4vci-client
+
   examples/oid4vci-server-nestjs:
     dependencies:
       '@nestjs/common':
@@ -578,7 +587,14 @@ importers:
 
   packages/oid4vci: {}
 
-  packages/oid4vci-client: {}
+  packages/oid4vci-client:
+    dependencies:
+      '@vdcs/oid4vci':
+        specifier: workspace:*
+        version: link:../oid4vci
+      axios:
+        specifier: ^1.8.2
+        version: 1.8.2
 
   packages/oid4vci-nestjs:
     dependencies:
@@ -13138,7 +13154,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.9)
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
@@ -13876,7 +13892,7 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.9)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       '@babel/runtime-corejs3': 7.26.9
       '@babel/traverse': 7.26.9
       '@docusaurus/logger': 3.7.0
@@ -16124,7 +16140,7 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.1(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -25023,7 +25039,7 @@ snapshots:
 
   react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -25041,7 +25057,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.98.0(@swc/core@1.10.17(@swc/helpers@0.5.15))(esbuild@0.19.12)):
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
       webpack: 5.98.0(@swc/core@1.10.17(@swc/helpers@0.5.15))(esbuild@0.19.12)
 
@@ -25205,13 +25221,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       react: 19.0.0
       react-router: 5.3.4(react@19.0.0)
 
   react-router-dom@5.3.4(react@19.0.0):
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -25222,7 +25238,7 @@ snapshots:
 
   react-router@5.3.4(react@19.0.0):
     dependencies:
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.27.1
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0


### PR DESCRIPTION
## What is changed
1. Implement oid4vci-client package
2. Add example project for oid4vci-client package


## Todo
1. Modify details after oid4vci-nestjs package updated (Currently oid4vci-client is based on [example-issuer-server](https://github.com/hopae-official/Verifiable-Digital-Credentials/tree/main/examples/example-issuer-server))
2. Support authorization code flow