### PR TITLE
fix: typo on pre-authorized_code

### DIFF
--- a/packages/oid4vci-nestjs/src/services/oid4vci.service.ts
+++ b/packages/oid4vci-nestjs/src/services/oid4vci.service.ts
@@ -107,7 +107,7 @@ export class Oid4VciService {
             options.credential_configuration_ids ?? [],
           grants: {
             'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
-              pre_authorized_code,
+              'pre-authorized_code': pre_authorized_code,
               tx_code,
               authorization_server,
             },
@@ -132,7 +132,7 @@ export class Oid4VciService {
             credential_offer: credentialOffer,
             credential_offer_uri,
             credential_offer_uri_key: uuid,
-            pre_authorized_code,
+            'pre-authorized_code': pre_authorized_code,
             tx_code: txCodeValue,
           };
         }
@@ -140,7 +140,7 @@ export class Oid4VciService {
         return {
           raw: rawCredentialOffer,
           credential_offer: credentialOffer,
-          pre_authorized_code,
+          'pre-authorized_code': pre_authorized_code,
           tx_code: txCodeValue,
         };
       }

--- a/packages/oid4vci-nestjs/src/types/credential_offer.ts
+++ b/packages/oid4vci-nestjs/src/types/credential_offer.ts
@@ -44,7 +44,7 @@ export type AuthorizationCodeGrant = {
 
 export type PreAuthorizedCodeGrant = {
   'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
-    pre_authorized_code: string;
+    'pre-authorized_code': string;
     tx_code?: TxCode;
     authorization_server?: string;
   };
@@ -80,6 +80,6 @@ export type CredentialOfferResponse = {
   credential_offer: string;
   credential_offer_uri?: string;
   credential_offer_uri_key?: string;
-  pre_authorized_code?: string;
+  'pre-authorized_code'?: string;
   tx_code?: string;
 };

--- a/packages/oid4vci/src/types/credential_offer.ts
+++ b/packages/oid4vci/src/types/credential_offer.ts
@@ -44,7 +44,7 @@ export type AuthorizationCodeGrant = {
 
 export type PreAuthorizedCodeGrant = {
   'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
-    pre_authorized_code: string;
+    'pre-authorized_code': string;
     tx_code?: TxCode;
     authorization_server?: string;
   };
@@ -72,7 +72,7 @@ export type CredentialOffer = {
  * @param credential_offer - URL encoded credential offer
  * @param credential_offer_uri - URL encoded credential offer URI (when useRef is true)
  * @param credential_offer_uri_key - Key of credential offer URI (when useRef is true)
- * @param pre_authorized_code - Pre-authorized code (when type is pre-authorized_code)
+ * @param pre-authorized_code - Pre-authorized code (when type is pre-authorized_code)
  * @param tx_code - Transaction code (when type is pre-authorized_code)
  */
 export type CredentialOfferResponse = {
@@ -80,7 +80,6 @@ export type CredentialOfferResponse = {
   credential_offer: string;
   credential_offer_uri?: string;
   credential_offer_uri_key?: string;
-  pre_authorized_code?: string;
+  'pre-authorized_code'?: string;
   tx_code?: string;
 };
-


### PR DESCRIPTION
Fix typo `pre_authorized_code` to `pre-authorized_code`