### PR TITLE
Correct response in no credential_sets case

### DIFF
--- a/packages/dcql/src/dcql.ts
+++ b/packages/dcql/src/dcql.ts
@@ -109,21 +109,33 @@ export class DCQL {
       return { match: false };
     }
 
-    // If credential_sets is not defined, return all matched credentials
-    if (!this._credential_sets || this._credential_sets.length === 0) {
-      return {
-        match: true,
-        matchedCredentials: allMatches,
-      };
-    }
-
-    // Handle credential sets if they exist
+    // Credential IDs matched in dataRecords
     const matchedIds = new Set(
       allMatches.map((match) => {
         const serialized = match.dcqlCredential.serialize();
         return serialized.id;
       }),
     );
+
+    // If credential_sets is not defined
+    if (!this._credential_sets || this._credential_sets.length === 0) {
+      // All IDs in Credential Query
+      const allCredentialIds = this._credentials.map((c) => c.serialize().id);
+
+      const everyCredentialSatisfied = allCredentialIds.every((id) =>
+        matchedIds.has(id),
+      );
+      // If any credential is missing in allMatches, we can't match
+      if (!everyCredentialSatisfied) {
+        return { match: false };
+      }
+      // If all credentials are matched, we can match and return all matched credentials
+      return {
+        match: true,
+        matchedCredentials: allMatches,
+      };
+    }
+
 
     // First, separate required credential sets
     const requiredSets = this._credential_sets.filter(

--- a/packages/dcql/src/test/dcql.spec.ts
+++ b/packages/dcql/src/test/dcql.spec.ts
@@ -227,5 +227,64 @@ describe('DCQL', () => {
         ],
       });
     });
+    
+    it('test 2', () => {
+      const rawDcql: rawDCQL = {
+        credentials: [
+          {
+            id: 'cred-1',
+            format: 'dc+sd-jwt',
+            meta: { vct_value: 'vct-1' },
+          },
+          {
+            id: 'cred-2',
+            format: 'dc+sd-jwt',
+            meta: { vct_value: 'vct-2' },
+          },
+        ],
+      };
+      const dcql = DCQL.parse(rawDcql);
+      const result = dcql.match([{ vct: 'vct-1', name: 'name-1' }]);
+      expect(result).toEqual({
+        match: false,
+      });
+    });
+
+    it('test 3', () => {
+      const claim = { path: ['name'], value: ['name-1'] };
+      const rawDcql: rawDCQL = {
+        credentials: [
+          {
+            id: 'cred-1',
+            format: 'dc+sd-jwt',
+            meta: { vct_value: 'vct-1' },
+            claims: [claim]
+          },
+          {
+            id: 'cred-2',
+            format: 'dc+sd-jwt',
+            meta: { vct_value: 'vct-2' },
+          },
+        ],
+        credential_sets: [
+          {
+            options: [['cred-1'], ['cred-2']],
+            required: true,
+          },
+        ],
+      };
+      const dcql = DCQL.parse(rawDcql);
+      const result = dcql.match([{ vct: 'vct-1', name: 'name-1' }]);
+      expect(result).toEqual({
+        match: true,
+        matchedCredentials: [
+          {
+            credential: { vct: 'vct-1', name: 'name-1' },
+            matchedClaims: [claim],
+            dataIndex: 0,
+          },
+        ],
+      });
+    });
   });
 });


### PR DESCRIPTION
Edit dcql.ts to align with OID4VP spec. Return {match: false} if any credentials in credential query is missing in Data Record, in no credential_set case.

Also added two test cases in dcql.spec.ts